### PR TITLE
Added :field identifier for the path.

### DIFF
--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -84,7 +84,7 @@ class UploadBehavior extends Behavior
 
             if (strpos($fieldOption['path'], ':field') && !isset($fieldOption['field'])) {
                 throw new \LogicException(__('The field option for the {0} field is required if you use the :field identifier in your path.', $field));
-            // }
+            }
 
             if (isset($fieldOption['prefix']) && (is_bool($fieldOption['prefix']) || is_string($fieldOption['prefix']))) {
                 $this->_prefix = $fieldOption['prefix'];


### PR DESCRIPTION
the :field identifier is defined using the 'field' key in the 'fields' array and is a field of the entity

The the example below will use the slug of the post to rename the upload image
````
$this->addBehavior('Xety/Cake3Upload.Upload', [
    'fields' => [
        'header_img' => [
            'path' => 'img/upload/:field',
            'field' => 'slug'
        ]
    ]
]);
````